### PR TITLE
Change farcaster packages version to `latest`

### DIFF
--- a/bin/init.js
+++ b/bin/init.js
@@ -281,12 +281,12 @@ export async function init() {
 
   // Add dependencies
   packageJson.dependencies = {
-    "@farcaster/auth-client": "^0.3.0",
-    "@farcaster/auth-kit": "^0.6.0",
-    "@farcaster/frame-core": "^0.0.29", 
-    "@farcaster/frame-node": "^0.0.18",
-    "@farcaster/frame-sdk": "^0.0.31",
-    "@farcaster/frame-wagmi-connector": "^0.0.19",
+    "@farcaster/auth-client": "latest",
+    "@farcaster/auth-kit": "latest",
+    "@farcaster/frame-core": "latest", 
+    "@farcaster/frame-node": "latest",
+    "@farcaster/frame-sdk": "latest",
+    "@farcaster/frame-wagmi-connector": "latest",
     "@radix-ui/react-label": "^2.1.1",
     "@tanstack/react-query": "^5.61.0",
     "@upstash/redis": "^1.34.3",

--- a/bin/init.js
+++ b/bin/init.js
@@ -281,12 +281,12 @@ export async function init() {
 
   // Add dependencies
   packageJson.dependencies = {
-    "@farcaster/auth-client": "latest",
-    "@farcaster/auth-kit": "latest",
-    "@farcaster/frame-core": "latest", 
-    "@farcaster/frame-node": "latest",
-    "@farcaster/frame-sdk": "latest",
-    "@farcaster/frame-wagmi-connector": "latest",
+    "@farcaster/auth-client": ">=0.3.0 <1.0.0",
+    "@farcaster/auth-kit": ">=0.6.0 <1.0.0",
+    "@farcaster/frame-core": ">=0.0.29 <1.0.0",
+    "@farcaster/frame-node": ">=0.0.18 <1.0.0",
+    "@farcaster/frame-sdk": ">=0.0.31 <1.0.0",
+    "@farcaster/frame-wagmi-connector": ">=0.0.19 <1.0.0",
     "@radix-ui/react-label": "^2.1.1",
     "@tanstack/react-query": "^5.61.0",
     "@upstash/redis": "^1.34.3",


### PR DESCRIPTION
Since the farcaster packages are getting updates quite frequently, which include new features its better to install the latest version of those sdks instead of predefined. 

For example:
The CLI install  "@farcaster/frame-sdk" `0.0.31` instead of `0.0.34`, which includes the `composeCast` function.