### PR TITLE
fix: add @pigment-css/react as dependency

### DIFF
--- a/bin/init.js
+++ b/bin/init.js
@@ -496,6 +496,7 @@ export async function init(
     '@farcaster/mini-app-solana': '>=0.0.17 <1.0.0',
     '@farcaster/quick-auth': '>=0.0.7 <1.0.0',
     '@neynar/react': '^1.2.15',
+    '@pigment-css/react': '^0.0.30',
     '@radix-ui/react-label': '^2.1.1',
     '@solana/wallet-adapter-react': '^0.15.38',
     '@tanstack/react-query': '^5.61.0',


### PR DESCRIPTION
@neynar/react requires @pigment-css/react at runtime but it wasn't included in the generated package.json, causing module resolution errors.

This fixes the issue where newly created mini apps fail with: 'Module not found: Can't resolve @pigment-css/react'