### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/components/ui/tabs/WalletTab.tsx
+++ b/src/components/ui/tabs/WalletTab.tsx
@@ -169,11 +169,12 @@ export function WalletTab() {
    */
   useEffect(() => {
     // Check if we're in a Farcaster client environment
-    const isInFarcasterClient = typeof window !== 'undefined' && 
-      (window.location.href.includes('warpcast.com') || 
-       window.location.href.includes('farcaster') ||
-       window.ethereum?.isFarcaster ||
-       context?.client);
+    const isInFarcasterClient = typeof window !== 'undefined' && (() => {
+      const hostname = window.location.hostname.toLowerCase();
+      const isWarpcastHost = hostname === 'warpcast.com' || hostname.endsWith('.warpcast.com');
+      const isFarcasterHost = hostname === 'farcaster.com' || hostname.endsWith('.farcaster.com');
+      return isWarpcastHost || isFarcasterHost || window.ethereum?.isFarcaster || context?.client;
+    })();
     
     if (context?.user?.fid && !isConnected && connectors.length > 0 && isInFarcasterClient) {
       console.log("Attempting auto-connection with Farcaster context...");


### PR DESCRIPTION
Potential fix for [https://github.com/neynarxyz/create-farcaster-mini-app/security/code-scanning/2](https://github.com/neynarxyz/create-farcaster-mini-app/security/code-scanning/2)

In general, to fix this issue, we should avoid substring checks on the full URL (`href`) and instead inspect the parsed URL components, primarily `hostname`. For browser code, `window.location.hostname` already exposes the host part. We can then check equality or well-defined patterns (e.g., exact host match or whitelisted subdomains) instead of free-form substring matches.

For this specific component, the intent is to detect if the app is running in a Farcaster-related client, such as Warpcast. The best, minimal-change fix is to replace:

```ts
window.location.href.includes('warpcast.com') || 
window.location.href.includes('farcaster')
```

with a hostname-based check that safely matches relevant hosts. For example, use `window.location.hostname` and compare against an explicit list of allowed host suffixes/prefixes, or use a simple, well-scoped regular expression. To keep things simple and not alter behavior too much, we can:

- Read `const hostname = window.location.hostname.toLowerCase();`
- Consider it a Farcaster client if:
  - The hostname is exactly `warpcast.com`, or
  - It is a subdomain of `warpcast.com` (ends with `.warpcast.com`), or
  - It contains `farcaster` as a distinct part of the hostname (e.g., starts with `farcaster.` or ends with `.farcaster.com`, depending on the expected deployment targets).

Since we must not assume extra app-specific details, we’ll keep a conservative, explicit set that clearly matches Warpcast while still honoring a generic “farcaster” host marker, using safe hostname checks rather than full-URL substring checks.

Concretely, in `src/components/ui/tabs/WalletTab.tsx`, within the `useEffect` that defines `isInFarcasterClient`, we will:

1. Introduce a `hostname` local variable derived from `window.location.hostname` (guarded by the existing `typeof window !== 'undefined'` check).
2. Compute `const isWarpcastHost = hostname === 'warpcast.com' || hostname.endsWith('.warpcast.com');`
3. Optionally compute `const isFarcasterHost = hostname === 'farcaster.com' || hostname.endsWith('.farcaster.com');` as a safe, host-scoped analogue to the previous generic `'farcaster'` substring check.
4. Replace the `window.location.href.includes(...)` expressions with `isWarpcastHost || isFarcasterHost`.

No new imports or external libraries are needed; all logic will be inlined in the hook.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Farcaster environment detection to address incomplete URL sanitization.
> 
> - Replaces `window.location.href.includes(...)` with parsed `hostname` checks (`warpcast.com` and `farcaster.com`, including subdomains) in `WalletTab.tsx`
> - Keeps existing checks for `window.ethereum?.isFarcaster` and `context?.client` to determine `isInFarcasterClient`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7ff1ca502339ca176131888a8f43686436dcecf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->